### PR TITLE
Updated Nucleo OpenOCD configuration to support new OpenOCD version

### DIFF
--- a/nucleo_l152re/nucleo-l152re.cfg
+++ b/nucleo_l152re/nucleo-l152re.cfg
@@ -4,7 +4,7 @@
 # STMicroelectronics ST-LINK/V2-1 in-circuit debugger/programmer
 #
 
-interface hla
+adapter driver hla
 hla_layout stlink
 hla_device_desc "ST-LINK/V2-1"
 hla_vid_pid 0x0483 0x374b
@@ -41,9 +41,9 @@ if { [info exists WORKAREASIZE] } {
 
 # JTAG speed should be <= F_CPU/6.
 # F_CPU after reset is 2MHz, so use F_JTAG max = 333kHz
-adapter_khz 300
+adapter speed 300
 
-adapter_nsrst_delay 100
+adapter srst delay 100
 if {[using_jtag]} {
  jtag_ntrst_delay 100
 }
@@ -89,7 +89,8 @@ if {[using_jtag]} {
 }
 
 set _TARGETNAME $_CHIPNAME.cpu
-target create $_TARGETNAME cortex_m -endian $_ENDIAN -chain-position $_TARGETNAME
+dap create dap_name -chain-position $_TARGETNAME
+target create $_TARGETNAME cortex_m -endian $_ENDIAN -dap dap_name
 
 $_TARGETNAME configure -work-area-phys 0x20000000 -work-area-size $_WORKAREASIZE -work-area-backup 0
 


### PR DESCRIPTION
* Made creation of the DAP explicit because newer versions of OpenOCD do no longer create it implicitly
* Updated some commands to newer versions, fixing deprecation warnings
    * `interface -> adapter driver`
    * `adapter_khz -> adapter speed`
    * `adapter_nsrst_delay -> adapter srst delay`